### PR TITLE
changes the minimum height to adapt to the image height

### DIFF
--- a/VSAlert/VSAlertController.m
+++ b/VSAlert/VSAlertController.m
@@ -674,7 +674,11 @@ static os_log_t alert_log;
     self.alertImage.image = self.image;
 
     // Update Constraints
-    self.headerViewHeightConstraint.constant = (BOOL)self.alertImage.image ? 180.0f : 0.0f;
+    float height = 0.0f;
+    if (self.alertImage.image != nil) {
+        height = self.alertImage.image.size.height >= 180 ? 180.0f : self.alertImage.image.size.height;
+    }
+    self.headerViewHeightConstraint.constant = height;
 
     // Set Up Background Tap Gesture Recognizer If Needed
     if (self.dismissOnBackgroundTap) {


### PR DESCRIPTION
* **What kind of change does this pull request introduce?** (Bug fix, feature, etc.)
<!-- Describe your changes here -->
Feature
Allow the minimum height to be same as the image

* **What is the current behavior?** (You can also link to an open issue here)
<!-- If desribing a bug, tell us about your issue. If describing a new feature, tell us why this old behavior isn't ideal-->
The minimum height is always 180 pixels, despite the size of the image

* **What is the new behavior, if applicable?**
<!-- Tell us about the new behavior -->
The minimum height will be the image height
The maximum height will be 180

* **Does this pull request introduce a breaking change?** (What changes do users of older releases need to make?)
<!-- If there is a breaking change, describe what older users might need to do -->
There might some differences if the images are less then 180 pixels in height, but not breaking changes

* **Anything else people should know?**
<!-- Self Explanatory -->
